### PR TITLE
Fix/twtg corrected ts vs device profile

### DIFF
--- a/vendors/twtg/models/neon-ts/model.yaml
+++ b/vendors/twtg/models/neon-ts/model.yaml
@@ -1,6 +1,6 @@
-# Commercial name of the model 
+# Commercial name of the model
 name: NEON Temperature Sensor
-# Functional description of the product. Maximum 500 characters. 
+# Functional description of the product. Maximum 500 characters.
 description: "The NEON Temperature Sensor measures surface temperatures and can alert on temperature differences occurring. This folder contains the latest product documentation, please note that documents may be updated regularly."
 # Logo of the device
 logo: twtg-ts.jpg
@@ -9,33 +9,33 @@ product:
     name: TWTG/TS
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
-deviceProfileId: 
+deviceProfileId:
     - twtg_RFGroup1_1.0.2revB_classA
     - twtg_RFGroup2_1.0.2revB_classA
- 
-# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings. 
-# Maximum device TX Conducted output power in dBm. 
-maxTxPower: 14
-# Minimum device TX Conducted output power in dBm. 
-minTxPower: 5
-# Maximum device TX Radiated output power in dBm.  
-maxTxEIRP: 6
-# Minimum device TX Radiated output power in dBm.  
-minTxEIRP: 4
-# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'  
-# or 'random' (not known, changes over time). 
+
+# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings.
+# Maximum device TX Conducted output power in dBm.
+maxTxPower:
+# Minimum device TX Conducted output power in dBm.
+minTxPower:
+# Maximum device TX Radiated output power in dBm.
+maxTxEIRP:
+# Minimum device TX Radiated output power in dBm.
+minTxEIRP:
+# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'
+# or 'random' (not known, changes over time).
 motionIndicator: NEAR_STATIC
- 
-# Is your device certified by the LoRa Alliance? Possible values: true, false. 
-LoRaWANCertified: true
+
+# Is your device certified by the LoRa Alliance? Possible values: true, false.
+LoRaWANCertified: false
 # Always mandatory: `<vendorId>:<modelName>:<modelVersion>` (You should have only one per model)
 modelId: twtg:neon-ts:1
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
-protocolId: 
-# DataSheet URL (optional) 
+protocolId:
+# DataSheet URL (optional)
 specificationURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/blob/main/TS/TWTG-NEON_Temperature-Sensor_Product-Sheet_B1.pdf
-# User Guide URL (optional) 
+# User Guide URL (optional)
 userGuideURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/tree/main/TS/Installation%20%26%20Use
-# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md 
+# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md
 sensors:
     - temperature:Cel

--- a/vendors/twtg/models/neon-ts/model.yaml
+++ b/vendors/twtg/models/neon-ts/model.yaml
@@ -10,8 +10,8 @@ product:
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
 deviceProfileId: 
-    - twtg_RFGroup1_RP2-1.0.4_classA
-    - twtg_RFGroup2_RP2-1.0.4_classA
+    - twtg_RFGroup1_1.0.2revB_classA
+    - twtg_RFGroup2_1.0.2revB_classA
  
 # You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings. 
 # Maximum device TX Conducted output power in dBm. 

--- a/vendors/twtg/models/neon-tt/model.yaml
+++ b/vendors/twtg/models/neon-tt/model.yaml
@@ -1,6 +1,6 @@
-# Commercial name of the model 
+# Commercial name of the model
 name: TWTG NEON Temperature Transmitter Sensor
-# Functional description of the product. Maximum 500 characters. 
+# Functional description of the product. Maximum 500 characters.
 description: "The NEON Temperature Transmitter provides insight on extreme temperatures and can send alerts if set triggers are reached. This folder contains the latest product documentation, please note that documents may be updated regularly."
 # Logo of the device
 logo: twtg-tt.png
@@ -9,43 +9,45 @@ product:
     name: TWTG/TT
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
-deviceProfileId: 
+deviceProfileId:
+    - twtg_RFGroup1_1.0.2revB_classA
+    - twtg_RFGroup2_1.0.2revB_classA
     - twtg_RFGroup1_RP2-1.0.4_classA
     - twtg_RFGroup2_RP2-1.0.4_classA
- 
-# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings. 
-# Maximum device TX Conducted output power in dBm. 
-maxTxPower: 14
-# Minimum device TX Conducted output power in dBm. 
-minTxPower: 5
-# Maximum device TX Radiated output power in dBm.  
-maxTxEIRP: 6
-# Minimum device TX Radiated output power in dBm.  
-minTxEIRP: 4
-# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'  
-# or 'random' (not known, changes over time). 
+
+# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings.
+# Maximum device TX Conducted output power in dBm.
+maxTxPower:
+# Minimum device TX Conducted output power in dBm.
+minTxPower:
+# Maximum device TX Radiated output power in dBm.
+maxTxEIRP:
+# Minimum device TX Radiated output power in dBm.
+minTxEIRP:
+# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'
+# or 'random' (not known, changes over time).
 motionIndicator: NEAR_STATIC
- 
-# Is your device certified by the LoRa Alliance? Possible values: true, false. 
-LoRaWANCertified: true
+
+# Is your device certified by the LoRa Alliance? Possible values: true, false.
+LoRaWANCertified: false
 # Always mandatory: `<vendorId>:<modelName>:<modelVersion>` (You should have only one per model)
 modelId: twtg:neon-tt:1
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
 protocolId: twtg:neon-tt:4
-# DataSheet URL (optional) 
+# DataSheet URL (optional)
 specificationURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/blob/main/TT/6015_P20-002_Data-Sheet-NEON-Temperature-Transmitter_C.pdf
-# User Guide URL (optional) 
+# User Guide URL (optional)
 userGuideURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/tree/main/TT/Installation%20%26%20Use
-# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md 
-sensors: 
+# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md
+sensors:
     - temperature:K
 # Driver examples
 # A list of examples description that are compatible with this model
 examples:
     - twtg:neon-tt:4:
-        - "TT Boot message – Payload pattern"
-        - "TT Activated message – Payload pattern"
-        - "TT Deactivated message – Payload pattern"
-        - "TT Sensor normal event message – Payload pattern"
-        - "TT Sensor extended event message – Payload pattern"
-        - "TT Device status message – Payload pattern"
+          - "TT Boot message – Payload pattern"
+          - "TT Activated message – Payload pattern"
+          - "TT Deactivated message – Payload pattern"
+          - "TT Sensor normal event message – Payload pattern"
+          - "TT Sensor extended event message – Payload pattern"
+          - "TT Device status message – Payload pattern"

--- a/vendors/twtg/models/neon-vb/model.yaml
+++ b/vendors/twtg/models/neon-vb/model.yaml
@@ -1,6 +1,6 @@
-# Commercial name of the model 
+# Commercial name of the model
 name: TWTG NEON Vibration Sensor
-# Functional description of the product. Maximum 500 characters. 
+# Functional description of the product. Maximum 500 characters.
 description: "The NEON Vibration Sensor provides insight on vibrations (acceleration and velocity) of industrial equipment. Triggers can be set, based on which the sensors can send alerts."
 # Logo of the device
 logo: twtg-vb.png
@@ -9,35 +9,37 @@ product:
     name: TWTG/VB
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
-deviceProfileId: 
+deviceProfileId:
+    - twtg_RFGroup1_1.0.2revB_classA
+    - twtg_RFGroup2_1.0.2revB_classA
     - twtg_RFGroup1_RP2-1.0.4_classA
     - twtg_RFGroup2_RP2-1.0.4_classA
- 
-# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings. 
-# Maximum device TX Conducted output power in dBm. 
-maxTxPower: 14
-# Minimum device TX Conducted output power in dBm. 
-minTxPower: 5
-# Maximum device TX Radiated output power in dBm.  
-maxTxEIRP: 6
-# Minimum device TX Radiated output power in dBm.  
-minTxEIRP: 4
-# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'  
-# or 'random' (not known, changes over time). 
+
+# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings.
+# Maximum device TX Conducted output power in dBm.
+maxTxPower:
+# Minimum device TX Conducted output power in dBm.
+minTxPower:
+# Maximum device TX Radiated output power in dBm.
+maxTxEIRP:
+# Minimum device TX Radiated output power in dBm.
+minTxEIRP:
+# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'
+# or 'random' (not known, changes over time).
 motionIndicator: NEAR_STATIC
- 
-# Is your device certified by the LoRa Alliance? Possible values: true, false. 
-LoRaWANCertified: true
+
+# Is your device certified by the LoRa Alliance? Possible values: true, false.
+LoRaWANCertified: false
 # Always mandatory: `<vendorId>:<modelName>:<modelVersion>` (You should have only one per model)
 modelId: twtg:neon-vb:1
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
 protocolId: twtg:neon-vb:3
-# DataSheet URL (optional) 
+# DataSheet URL (optional)
 specificationURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/blob/main/VB/6016_P20-002_Data-Sheet-NEON-Vibration-Sensor_C.pdf
-# User Guide URL (optional) 
+# User Guide URL (optional)
 userGuideURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/tree/main/VB/Installation%20%26%20Use
-# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md 
-sensors: 
+# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md
+sensors:
     - temperature:Cel
     - velocity:mm/s
     - acceleration:m/s2
@@ -46,14 +48,14 @@ sensors:
 # A list of examples description that are compatible with this model
 examples:
     - twtg:neon-vb:3:
-        - "Config_update_ans payload sensor_cond_conf v3"
-        - "sensor data example for decoder v3"
-        - "Boot payload pattern v3"
-        - "Device_status payload pattern v3"
-        - "Sensor_event payload normal pattern v3"
-        - "Sensor_event payload extended pattern v3"
-        - "Sensor_event payload extended pattern v3"
-        - "Decoder activated_message v3"
-        - "Decoder deactivated_message payload pattern user_tiggered v3"
-        - "Decoder deactivated_message payload pattern activation_user_timeout v3"
-        - "Decoder deactivated_message payload pattern activation_sensor_comm_fail v3"
+          - "Config_update_ans payload sensor_cond_conf v3"
+          - "sensor data example for decoder v3"
+          - "Boot payload pattern v3"
+          - "Device_status payload pattern v3"
+          - "Sensor_event payload normal pattern v3"
+          - "Sensor_event payload extended pattern v3"
+          - "Sensor_event payload extended pattern v3"
+          - "Decoder activated_message v3"
+          - "Decoder deactivated_message payload pattern user_tiggered v3"
+          - "Decoder deactivated_message payload pattern activation_user_timeout v3"
+          - "Decoder deactivated_message payload pattern activation_sensor_comm_fail v3"

--- a/vendors/twtg/models/neon-vs-mt/model.yaml
+++ b/vendors/twtg/models/neon-vs-mt/model.yaml
@@ -10,8 +10,8 @@ product:
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
 deviceProfileId: 
-    - twtg_RFGroup1_RP2-1.0.4_classA
-    - twtg_RFGroup2_RP2-1.0.4_classA
+    - twtg_RFGroup1_1.0.2revB_classA
+    - twtg_RFGroup2_1.0.2revB_classA
  
 # You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings. 
 # Maximum device TX Conducted output power in dBm. 

--- a/vendors/twtg/models/neon-vs-mt/model.yaml
+++ b/vendors/twtg/models/neon-vs-mt/model.yaml
@@ -1,6 +1,6 @@
-# Commercial name of the model 
+# Commercial name of the model
 name: NEON Multi Turn Valve Sensor
-# Functional description of the product. Maximum 500 characters. 
+# Functional description of the product. Maximum 500 characters.
 description: "The NEON multi-turn Valve Sensor provides insight into the open or closed state of manually operated valves. This folder contains the latest product documentation, please note that documents may be updated regularly."
 # Logo of the device
 logo: twtg-vs-mt.jpg
@@ -9,32 +9,32 @@ product:
     name: TWTG/VSMT
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
-deviceProfileId: 
+deviceProfileId:
     - twtg_RFGroup1_1.0.2revB_classA
     - twtg_RFGroup2_1.0.2revB_classA
- 
-# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings. 
-# Maximum device TX Conducted output power in dBm. 
-maxTxPower: 14
-# Minimum device TX Conducted output power in dBm. 
-minTxPower: 5
-# Maximum device TX Radiated output power in dBm.  
-maxTxEIRP: 6
-# Minimum device TX Radiated output power in dBm.  
-minTxEIRP: 4
-# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'  
-# or 'random' (not known, changes over time). 
+
+# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings.
+# Maximum device TX Conducted output power in dBm.
+maxTxPower:
+# Minimum device TX Conducted output power in dBm.
+minTxPower:
+# Maximum device TX Radiated output power in dBm.
+maxTxEIRP:
+# Minimum device TX Radiated output power in dBm.
+minTxEIRP:
+# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'
+# or 'random' (not known, changes over time).
 motionIndicator: NEAR_STATIC
- 
-# Is your device certified by the LoRa Alliance? Possible values: true, false. 
-LoRaWANCertified: true
+
+# Is your device certified by the LoRa Alliance? Possible values: true, false.
+LoRaWANCertified: false
 # Always mandatory: `<vendorId>:<modelName>:<modelVersion>` (You should have only one per model)
 modelId: twtg:neon-vs-mt:1
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
-protocolId: 
-# DataSheet URL (optional) 
+protocolId:
+# DataSheet URL (optional)
 specificationURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/blob/main/VS-MT/TWTG%20-NEON_Valve%20-Sensor-MT_Product-Sheet_B1.pdf
-# User Guide URL (optional) 
+# User Guide URL (optional)
 userGuideURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/tree/main/VS-MT/Installation%20%26%20Use
-# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md 
-sensors: 
+# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md
+sensors:

--- a/vendors/twtg/models/neon-vs-qt/model.yaml
+++ b/vendors/twtg/models/neon-vs-qt/model.yaml
@@ -10,8 +10,8 @@ product:
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
 deviceProfileId: 
-    - twtg_RFGroup1_RP2-1.0.4_classA
-    - twtg_RFGroup2_RP2-1.0.4_classA
+    - twtg_RFGroup1_1.0.2revB_classA
+    - twtg_RFGroup2_1.0.2revB_classA
  
 # You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings. 
 # Maximum device TX Conducted output power in dBm. 

--- a/vendors/twtg/models/neon-vs-qt/model.yaml
+++ b/vendors/twtg/models/neon-vs-qt/model.yaml
@@ -1,6 +1,6 @@
-# Commercial name of the model 
+# Commercial name of the model
 name: NEON Quater Turn Valve Sensor
-# Functional description of the product. Maximum 500 characters. 
+# Functional description of the product. Maximum 500 characters.
 description: "The NEON quarter-turn Valve Sensor provides insight into the open or closed state of manually operated valves. This folder contains the latest product documentation, please note that documents may be updated regularly."
 # Logo of the device
 logo: twtg-vs-qt.jpg
@@ -9,32 +9,32 @@ product:
     name: TWTG/VSQT
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
-deviceProfileId: 
+deviceProfileId:
     - twtg_RFGroup1_1.0.2revB_classA
     - twtg_RFGroup2_1.0.2revB_classA
- 
-# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings. 
-# Maximum device TX Conducted output power in dBm. 
-maxTxPower: 14
-# Minimum device TX Conducted output power in dBm. 
-minTxPower: 5
-# Maximum device TX Radiated output power in dBm.  
-maxTxEIRP: 6
-# Minimum device TX Radiated output power in dBm.  
-minTxEIRP: 4
-# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'  
-# or 'random' (not known, changes over time). 
+
+# You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings.
+# Maximum device TX Conducted output power in dBm.
+maxTxPower:
+# Minimum device TX Conducted output power in dBm.
+minTxPower:
+# Maximum device TX Radiated output power in dBm.
+maxTxEIRP:
+# Minimum device TX Radiated output power in dBm.
+minTxEIRP:
+# Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'
+# or 'random' (not known, changes over time).
 motionIndicator: NEAR_STATIC
- 
-# Is your device certified by the LoRa Alliance? Possible values: true, false. 
-LoRaWANCertified: true
+
+# Is your device certified by the LoRa Alliance? Possible values: true, false.
+LoRaWANCertified: false
 # Always mandatory: `<vendorId>:<modelName>:<modelVersion>` (You should have only one per model)
 modelId: twtg:neon-vs-qt:1
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
-protocolId: 
-# DataSheet URL (optional) 
+protocolId:
+# DataSheet URL (optional)
 specificationURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/blob/main/VS-QT/TWTG-NEON_Valve-sensor-QT_Product-Sheet_B1.pdf
-# User Guide URL (optional) 
+# User Guide URL (optional)
 userGuideURL: https://github.com/TWTG-R-D-B-V/neon-product-documentation/tree/main/VS-QT/Installation%20%26%20Use
-# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md 
-sensors: 
+# Available sensors following Actility ontology: https://github.com/actility/thingpark-iot-flow-js-driver/blob/master/UNITS.md
+sensors:

--- a/vendors/twtg/profiles/twtg_RFGroup1_1.0.2revB_classA.yaml
+++ b/vendors/twtg/profiles/twtg_RFGroup1_1.0.2revB_classA.yaml
@@ -7,14 +7,14 @@
 #    RFGroup3:   au915-928 (starting from LoRaWAN 1.0.2revC)
 #    RFGroup4: as923
 # Please do not change the existing IDs (Some may follow the old format)
-id: twtg_RFGroup2_RP2-1.0.4_classA
+id: twtg_RFGroup1_1.0.2revB_classA
 # LoRaWAN class of the Device: Possible values: [ A, B, C ] (Should not have several values)
 # 'A': Class A (Bi-directional end-devices with downlink listening only after uplink transmission)
 # 'B': Class B (Bi-directional end-devices with downlink listening on predefined synchronized pingslots)
 # 'C': Class C (Bi-directional end-devices with permanent downlink listening)
 loRaWANClass: A
 # Comma-separated list of regional profiles supported by this device. Possible values are eu868, us915, as923, au915, eu433, in865, kr920, ru864, cn470.
-ISMbands: us915
+ISMbands: eu868
 # Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'
 # or 'random' (not known, changes over time).
 # The motion indication property will not be taken into consideration here if it is overwritten in the model.yaml
@@ -27,21 +27,21 @@ mac:
     #(OTAA)
     overTheAirActivation: true
     # Supported version of the LoRaWAN MAC (Layer-2) specification. Possible values are '1.0.0/1.0.1', '1.0.2', '1.0.3', '1.0.4', '1.1'
-    loRaWANMacVersion: 1.0.4
+    loRaWANMacVersion: 1.0.2
     # Supported version of the LoRaWAN regional parameters (PHY) specification. Possible values are '1.0.2revA', '1.0.2revB', '1.0.2revC',
     # '1.0.3revA', 'RP2-1.0.0', 'RP2-1.0.1', 'RP2-1.0.2', 'RP2-1.0.3', 'RP2-1.0.4', 'RP2-1.0.5'.
-    regionalParameterVersion: RP2-1.0.4
+    regionalParameterVersion: 1.0.2revB
 
     # The device Tx Power Capabilities here will not be taken into consideration if it is overwritten in the model.yaml
     devicesTxPowerCapabilities:
         # Minimum device TX Conducted output power in dBm.
-        minTxPower: 5
+        minTxPower: -3
         # Maximum device TX Conducted output power in dBm.
         maxTxPower: 14
         # Minimum device TX Radiated output power in dBm.
-        minTxEIRP: 4
+        minTxEIRP: 8
         # Maximum device TX Radiated output power in dBm.
-        maxTxEIRP: 6
+        maxTxEIRP: 12
 
     uplinkFrameRepetition:
         # Maximum number of transmissions per uplink frame, supported by the device.
@@ -49,7 +49,7 @@ mac:
         # How many uplink transmissions does the device use in Confirmed mode if it doesn't receive any DL ACK?
         maxRedundancyForConfirmedUL:
 
-# The following section defines the default settings used by the device during iniial boot stage. Leave empty if your device respects the
+# The following section defines the default settings used by the device during initial boot stage. Leave empty if your device respects the
 # default values indicated by LoRaWAN Regional Parameters (PHY) specification. Personalize fields only when different from default PHY values.
 bootSettings:
     # Delay between the end of uplink transmission and the start of downlink RX1 slot, in milliseconds. Refer to 'receiveDelay1' in LoRaWAN
@@ -80,16 +80,16 @@ supportedMACCommands:
     devStatusReqAns: true
     joinRequestAccept: true
     dutyCycleReqAns: true
-    linkCheckReqAns: true
+    linkCheckReqAns: false
     rxParamSetupReqAns: true
     rxTimingSetupReqAns: true
     newChannelReqAns: true
     dlChannelReqAns: true
     txParamSetupReqAns: true
     pingSlotChannelReqAns: false
-    pingSlotInfoReqAns: true
-    deviceTimeReqAns: true
-    beaconFreqReqAns: true
+    pingSlotInfoReqAns: false
+    deviceTimeReqAns: false
+    beaconFreqReqAns: false
 
 # Does your device support [Technical Recommendation for LoRaWAN L2 1.0.x Join Security] recommending implemeting the DevNonce as a counter for
 # OTAA devices? See https://lora-alliance.org/resource_hub/technical-recommendations-for-preventing-state-synchronization-issues-around-lorawan-1-0-x-join-procedure/

--- a/vendors/twtg/profiles/twtg_RFGroup1_RP2-1.0.4_classA.yaml
+++ b/vendors/twtg/profiles/twtg_RFGroup1_RP2-1.0.4_classA.yaml
@@ -28,7 +28,7 @@ mac:
     overTheAirActivation: true
     # Supported version of the LoRaWAN MAC (Layer-2) specification. Possible values are '1.0.0/1.0.1', '1.0.2', '1.0.3', '1.0.4', '1.1'
     loRaWANMacVersion: 1.0.4
-    # Supported version of the LoRaWAN regional parameters (PHY) specification. Possible values are '1.0.2revA', '1.0.2revB', '1.0.2revC', 
+    # Supported version of the LoRaWAN regional parameters (PHY) specification. Possible values are '1.0.2revA', '1.0.2revB', '1.0.2revC',
     # '1.0.3revA', 'RP2-1.0.0', 'RP2-1.0.1', 'RP2-1.0.2', 'RP2-1.0.3', 'RP2-1.0.4', 'RP2-1.0.5'.
     regionalParameterVersion: RP2-1.0.4
 
@@ -43,21 +43,21 @@ mac:
         # Maximum device TX Radiated output power in dBm.
         maxTxEIRP: 6
 
-    uplinkFrameRepetition: 
-        # Maximum number of transmissions per uplink frame, supported by the device. 
+    uplinkFrameRepetition:
+        # Maximum number of transmissions per uplink frame, supported by the device.
         maxNbTrans:
         # How many uplink transmissions does the device use in Confirmed mode if it doesn't receive any DL ACK?
         maxRedundancyForConfirmedUL:
 
-# The following section defines the default settings used by the device during iniial boot stage. Leave empty if your device respects the 
+# The following section defines the default settings used by the device during iniial boot stage. Leave empty if your device respects the
 # default values indicated by LoRaWAN Regional Parameters (PHY) specification. Personalize fields only when different from default PHY values.
-bootSettings: 
-    # Delay between the end of uplink transmission and the start of downlink RX1 slot, in milliseconds. Refer to 'receiveDelay1' in LoRaWAN 
+bootSettings:
+    # Delay between the end of uplink transmission and the start of downlink RX1 slot, in milliseconds. Refer to 'receiveDelay1' in LoRaWAN
     # Specification.
-    rx1Delay: 1000
+    rx1Delay:
     # RX1 data rate offset, defining the offset between uplink data rate and the corresponding downlink data rate used for RX1 slot.
     rx1DROffset:
-    # Rx2 DataRate, used to send DL packets over RX2 slot. Note: Data Rate encoding is region-specific, see the applicable LoRaWAN Regional 
+    # Rx2 DataRate, used to send DL packets over RX2 slot. Note: Data Rate encoding is region-specific, see the applicable LoRaWAN Regional
     # Profile.
     rx2DataRate:
     # Rx2 Frequency expressed in MHz, used to send DL packets over RX2 slot.
@@ -91,11 +91,11 @@ supportedMACCommands:
     deviceTimeReqAns: true
     beaconFreqReqAns: true
 
-# Does your device support [Technical Recommendation for LoRaWAN L2 1.0.x Join Security] recommending implemeting the DevNonce as a counter for 
+# Does your device support [Technical Recommendation for LoRaWAN L2 1.0.x Join Security] recommending implemeting the DevNonce as a counter for
 # OTAA devices? See https://lora-alliance.org/resource_hub/technical-recommendations-for-preventing-state-synchronization-issues-around-lorawan-1-0-x-join-procedure/
 # Possible values: true, false. This field is automatically forced to true for LoRaWAN MAC versions 1.0.4 and 1.1.
 devNonceCounterBased: false
 
-# ProfileID as specified by LoRa Alliance in https://lora-alliance.org/wp-content/uploads/2020/10/LoRa_Alliance_Vendor_ID_for_QR_Code_02142022.pdf. 
+# ProfileID as specified by LoRa Alliance in https://lora-alliance.org/wp-content/uploads/2020/10/LoRa_Alliance_Vendor_ID_for_QR_Code_02142022.pdf.
 # This ID consists of 8 upper-case hexadecimal characters, 4 characters for VendorID + 4 characters for VendorProfileID.
 lorawanDeviceProfileID:

--- a/vendors/twtg/profiles/twtg_RFGroup2_1.0.2revB_classA.yaml
+++ b/vendors/twtg/profiles/twtg_RFGroup2_1.0.2revB_classA.yaml
@@ -7,7 +7,7 @@
 #    RFGroup3:   au915-928 (starting from LoRaWAN 1.0.2revC)
 #    RFGroup4: as923
 # Please do not change the existing IDs (Some may follow the old format)
-id: twtg_RFGroup2_RP2-1.0.4_classA
+id: twtg_RFGroup2_RP-1.0.2revB_classA
 # LoRaWAN class of the Device: Possible values: [ A, B, C ] (Should not have several values)
 # 'A': Class A (Bi-directional end-devices with downlink listening only after uplink transmission)
 # 'B': Class B (Bi-directional end-devices with downlink listening on predefined synchronized pingslots)
@@ -27,21 +27,21 @@ mac:
     #(OTAA)
     overTheAirActivation: true
     # Supported version of the LoRaWAN MAC (Layer-2) specification. Possible values are '1.0.0/1.0.1', '1.0.2', '1.0.3', '1.0.4', '1.1'
-    loRaWANMacVersion: 1.0.4
+    loRaWANMacVersion: 1.0.2
     # Supported version of the LoRaWAN regional parameters (PHY) specification. Possible values are '1.0.2revA', '1.0.2revB', '1.0.2revC',
     # '1.0.3revA', 'RP2-1.0.0', 'RP2-1.0.1', 'RP2-1.0.2', 'RP2-1.0.3', 'RP2-1.0.4', 'RP2-1.0.5'.
-    regionalParameterVersion: RP2-1.0.4
+    regionalParameterVersion: 1.0.2revB
 
     # The device Tx Power Capabilities here will not be taken into consideration if it is overwritten in the model.yaml
     devicesTxPowerCapabilities:
         # Minimum device TX Conducted output power in dBm.
-        minTxPower: 5
+        minTxPower: -3
         # Maximum device TX Conducted output power in dBm.
         maxTxPower: 14
         # Minimum device TX Radiated output power in dBm.
-        minTxEIRP: 4
+        minTxEIRP: 8
         # Maximum device TX Radiated output power in dBm.
-        maxTxEIRP: 6
+        maxTxEIRP: 12
 
     uplinkFrameRepetition:
         # Maximum number of transmissions per uplink frame, supported by the device.
@@ -49,12 +49,12 @@ mac:
         # How many uplink transmissions does the device use in Confirmed mode if it doesn't receive any DL ACK?
         maxRedundancyForConfirmedUL:
 
-# The following section defines the default settings used by the device during iniial boot stage. Leave empty if your device respects the
+# The following section defines the default settings used by the device during initial boot stage. Leave empty if your device respects the
 # default values indicated by LoRaWAN Regional Parameters (PHY) specification. Personalize fields only when different from default PHY values.
 bootSettings:
     # Delay between the end of uplink transmission and the start of downlink RX1 slot, in milliseconds. Refer to 'receiveDelay1' in LoRaWAN
     # Specification.
-    rx1Delay:
+    rx1Delay: 1000
     # RX1 data rate offset, defining the offset between uplink data rate and the corresponding downlink data rate used for RX1 slot.
     rx1DROffset:
     # Rx2 DataRate, used to send DL packets over RX2 slot. Note: Data Rate encoding is region-specific, see the applicable LoRaWAN Regional
@@ -80,16 +80,16 @@ supportedMACCommands:
     devStatusReqAns: true
     joinRequestAccept: true
     dutyCycleReqAns: true
-    linkCheckReqAns: true
+    linkCheckReqAns: false
     rxParamSetupReqAns: true
     rxTimingSetupReqAns: true
     newChannelReqAns: true
     dlChannelReqAns: true
     txParamSetupReqAns: true
     pingSlotChannelReqAns: false
-    pingSlotInfoReqAns: true
-    deviceTimeReqAns: true
-    beaconFreqReqAns: true
+    pingSlotInfoReqAns: false
+    deviceTimeReqAns: false
+    beaconFreqReqAns: false
 
 # Does your device support [Technical Recommendation for LoRaWAN L2 1.0.x Join Security] recommending implemeting the DevNonce as a counter for
 # OTAA devices? See https://lora-alliance.org/resource_hub/technical-recommendations-for-preventing-state-synchronization-issues-around-lorawan-1-0-x-join-procedure/

--- a/vendors/twtg/profiles/twtg_RFGroup2_RP2-1.0.4_classA.yaml
+++ b/vendors/twtg/profiles/twtg_RFGroup2_RP2-1.0.4_classA.yaml
@@ -37,7 +37,7 @@ mac:
         # Minimum device TX Conducted output power in dBm.
         minTxPower: 5
         # Maximum device TX Conducted output power in dBm.
-        maxTxPower: 14
+        maxTxPower: 8 # this is different compared to EU868 due to certification differences
         # Minimum device TX Radiated output power in dBm.
         minTxEIRP: 4
         # Maximum device TX Radiated output power in dBm.


### PR DESCRIPTION
@mostafaibr as discussed hereby the corrections to the VS/TS models.

There are small updates for TT and VB as well.

Note that some device models have profiles with two different LoRaWAN versions as it depends on the firmware which LoRaWAN version is used.