### PR TITLE
Fix/twtg neon regional parameters

### DIFF
--- a/vendors/twtg/models/neon-tt/model.yaml
+++ b/vendors/twtg/models/neon-tt/model.yaml
@@ -1,5 +1,5 @@
 # Commercial name of the model
-name: TWTG NEON Temperature Transmitter Sensor firmware v1
+name: TWTG NEON Temperature Transmitter (DS-TT-01-xx)
 # Functional description of the product. Maximum 500 characters.
 description: "The NEON Temperature Transmitter provides insight on extreme temperatures and can send alerts if set triggers are reached. This folder contains the latest product documentation, please note that documents may be updated regularly."
 # Logo of the device

--- a/vendors/twtg/models/neon-tt_v2/model.yaml
+++ b/vendors/twtg/models/neon-tt_v2/model.yaml
@@ -1,5 +1,5 @@
 # Commercial name of the model
-name: TWTG NEON Temperature Transmitter Sensor firmware v2
+name: TWTG NEON Temperature Transmitter (DS-TT-02-00)
 # Functional description of the product. Maximum 500 characters.
 description: "The NEON Temperature Transmitter provides insight on extreme temperatures and can send alerts if set triggers are reached. This folder contains the latest product documentation, please note that documents may be updated regularly."
 # Logo of the device

--- a/vendors/twtg/models/neon-tt_v2/model.yaml
+++ b/vendors/twtg/models/neon-tt_v2/model.yaml
@@ -10,8 +10,8 @@ product:
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
 deviceProfileId:
-    - twtg_RFGroup1_RP2-1.0.4_classA
-    - twtg_RFGroup2_RP2-1.0.4_classA
+    - twtg_RFGroup1_RP2-1.0.1_classA
+    - twtg_RFGroup2_RP2-1.0.1_classA
 
 # You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings.
 # Maximum device TX Conducted output power in dBm.

--- a/vendors/twtg/models/neon-vb/model.yaml
+++ b/vendors/twtg/models/neon-vb/model.yaml
@@ -1,5 +1,5 @@
 # Commercial name of the model
-name: TWTG NEON Vibration Sensor firmware v1
+name: TWTG NEON Vibration Sensor (DS-LD-01-xx with DS-VB-01-xx)
 # Functional description of the product. Maximum 500 characters.
 description: "The NEON Vibration Sensor provides insight on vibrations (acceleration and velocity) of industrial equipment. Triggers can be set, based on which the sensors can send alerts."
 # Logo of the device

--- a/vendors/twtg/models/neon-vb_v2/model.yaml
+++ b/vendors/twtg/models/neon-vb_v2/model.yaml
@@ -1,5 +1,5 @@
 # Commercial name of the model
-name: TWTG NEON Vibration Sensor firmware v2
+name: TWTG NEON Vibration Sensor (DS-LD-02-00 with DS-VB-02-00)
 # Functional description of the product. Maximum 500 characters.
 description: "The NEON Vibration Sensor provides insight on vibrations (acceleration and velocity) of industrial equipment. Triggers can be set, based on which the sensors can send alerts."
 # Logo of the device

--- a/vendors/twtg/models/neon-vb_v2/model.yaml
+++ b/vendors/twtg/models/neon-vb_v2/model.yaml
@@ -10,8 +10,8 @@ product:
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
 deviceProfileId:
-    - twtg_RFGroup1_RP2-1.0.4_classA
-    - twtg_RFGroup2_RP2-1.0.4_classA
+    - twtg_RFGroup1_RP2-1.0.1_classA
+    - twtg_RFGroup2_RP2-1.0.1_classA
 
 # You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings.
 # Maximum device TX Conducted output power in dBm.

--- a/vendors/twtg/profiles/twtg_RFGroup1_RP2-1.0.1_classA.yaml
+++ b/vendors/twtg/profiles/twtg_RFGroup1_RP2-1.0.1_classA.yaml
@@ -7,14 +7,14 @@
 #    RFGroup3:   au915-928 (starting from LoRaWAN 1.0.2revC)
 #    RFGroup4: as923
 # Please do not change the existing IDs (Some may follow the old format)
-id: twtg_RFGroup2_RP2-1.0.4_classA
+id: twtg_RFGroup1_RP2-1.0.1_classA
 # LoRaWAN class of the Device: Possible values: [ A, B, C ] (Should not have several values)
 # 'A': Class A (Bi-directional end-devices with downlink listening only after uplink transmission)
 # 'B': Class B (Bi-directional end-devices with downlink listening on predefined synchronized pingslots)
 # 'C': Class C (Bi-directional end-devices with permanent downlink listening)
 loRaWANClass: A
 # Comma-separated list of regional profiles supported by this device. Possible values are eu868, us915, as923, au915, eu433, in865, kr920, ru864, cn470.
-ISMbands: us915
+ISMbands: eu868
 # Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'
 # or 'random' (not known, changes over time).
 # The motion indication property will not be taken into consideration here if it is overwritten in the model.yaml
@@ -30,14 +30,14 @@ mac:
     loRaWANMacVersion: 1.0.4
     # Supported version of the LoRaWAN regional parameters (PHY) specification. Possible values are '1.0.2revA', '1.0.2revB', '1.0.2revC',
     # '1.0.3revA', 'RP2-1.0.0', 'RP2-1.0.1', 'RP2-1.0.2', 'RP2-1.0.3', 'RP2-1.0.4', 'RP2-1.0.5'.
-    regionalParameterVersion: RP2-1.0.4
+    regionalParameterVersion: RP2-1.0.1
 
     # The device Tx Power Capabilities here will not be taken into consideration if it is overwritten in the model.yaml
     devicesTxPowerCapabilities:
         # Minimum device TX Conducted output power in dBm.
         minTxPower: 5
         # Maximum device TX Conducted output power in dBm.
-        maxTxPower: 8 # this is different compared to EU868 due to certification differences
+        maxTxPower: 14
         # Minimum device TX Radiated output power in dBm.
         minTxEIRP: 4
         # Maximum device TX Radiated output power in dBm.

--- a/vendors/twtg/profiles/twtg_RFGroup2_RP2-1.0.1_classA.yaml
+++ b/vendors/twtg/profiles/twtg_RFGroup2_RP2-1.0.1_classA.yaml
@@ -7,14 +7,14 @@
 #    RFGroup3:   au915-928 (starting from LoRaWAN 1.0.2revC)
 #    RFGroup4: as923
 # Please do not change the existing IDs (Some may follow the old format)
-id: twtg_RFGroup1_RP2-1.0.4_classA
+id: twtg_RFGroup2_RP2-1.0.1_classA
 # LoRaWAN class of the Device: Possible values: [ A, B, C ] (Should not have several values)
 # 'A': Class A (Bi-directional end-devices with downlink listening only after uplink transmission)
 # 'B': Class B (Bi-directional end-devices with downlink listening on predefined synchronized pingslots)
 # 'C': Class C (Bi-directional end-devices with permanent downlink listening)
 loRaWANClass: A
 # Comma-separated list of regional profiles supported by this device. Possible values are eu868, us915, as923, au915, eu433, in865, kr920, ru864, cn470.
-ISMbands: eu868
+ISMbands: us915
 # Typical mobility profile of the device. Possible values are 'near_static' (also valid for static devices), 'walking_speed', 'vehicular_speed'
 # or 'random' (not known, changes over time).
 # The motion indication property will not be taken into consideration here if it is overwritten in the model.yaml
@@ -30,14 +30,14 @@ mac:
     loRaWANMacVersion: 1.0.4
     # Supported version of the LoRaWAN regional parameters (PHY) specification. Possible values are '1.0.2revA', '1.0.2revB', '1.0.2revC',
     # '1.0.3revA', 'RP2-1.0.0', 'RP2-1.0.1', 'RP2-1.0.2', 'RP2-1.0.3', 'RP2-1.0.4', 'RP2-1.0.5'.
-    regionalParameterVersion: RP2-1.0.4
+    regionalParameterVersion: RP2-1.0.1
 
     # The device Tx Power Capabilities here will not be taken into consideration if it is overwritten in the model.yaml
     devicesTxPowerCapabilities:
         # Minimum device TX Conducted output power in dBm.
         minTxPower: 5
         # Maximum device TX Conducted output power in dBm.
-        maxTxPower: 14
+        maxTxPower: 8 # this is different compared to EU868 due to certification differences
         # Minimum device TX Radiated output power in dBm.
         minTxEIRP: 4
         # Maximum device TX Radiated output power in dBm.


### PR DESCRIPTION
@mostafaibr corrected regional parameters DS-xx-02-xx devices

By mistake the regional version was made the same as the LoRaWAN MAC version.