### PR TITLE
TXIF-2492 - Changed Milesight's WS558's profiles to class C

### DIFF
--- a/vendors/milesight-iot/models/ws558/model.yaml
+++ b/vendors/milesight-iot/models/ws558/model.yaml
@@ -10,11 +10,11 @@ product:
     version: 1
 # ID(s) of the profile that defines the LoRaWAN characteristics of this model.
 deviceProfileId: 
-    - msight_RFGroup1_1.0.3a_classA
-    - msight_RFGroup4_1.0.3a_classA
-    - msight_us915-22dBm_1.0.3a_classA
-    - msight_au915-22dBm_1.0.3a_classA
-    - msight_cn470-19dBm_1.0.3a_classA
+    - msight_RFGroup1_1.0.3a_classC
+    - msight_RFGroup4_1.0.3a_classC
+    - msight_us915-22dBm_1.0.3a_classC
+    - msight_au915-22dBm_1.0.3a_classC
+    - msight_cn470-19dBm_1.0.3a_classC
 
 # You may optionally customize any of the following settings to override the generic value set in LoRaWAN device profiles associated with your model. Leave empty if you want to keep the Device Profile settings. 
 # Maximum device TX Conducted output power in dBm. 


### PR DESCRIPTION
Changed Milesight's WS558's LoRaWAN class from A to C