### PR TITLE
Fixed duplicate vaqa'o lite name

### DIFF
--- a/vendors/watteco/drivers/vaqa'o-plus_v4/driver.yaml
+++ b/vendors/watteco/drivers/vaqa'o-plus_v4/driver.yaml
@@ -1,7 +1,7 @@
 #Formal driver name
-name: vaqa'o lite driver
+name: vaqa'o plus driver
 # Simple description of the driver functionalities
-description: Decoder for vaqa'o lite
+description: Decoder for vaqa'o plus
 # Mandatory - id of the company that developed the driver
 # This id will be used to construct the id of the driver (Should be in lowercase, no special characters, maximum 8 characters)
 producerId: watteco

--- a/vendors/watteco/drivers/vaqa'o_v4/driver.yaml
+++ b/vendors/watteco/drivers/vaqa'o_v4/driver.yaml
@@ -1,7 +1,7 @@
 #Formal driver name
-name: vaqa'o lite driver
+name: vaqa'o driver
 # Simple description of the driver functionalities
-description: Decoder for vaqa'o lite
+description: Decoder for vaqa'o
 # Mandatory - id of the company that developed the driver
 # This id will be used to construct the id of the driver (Should be in lowercase, no special characters, maximum 8 characters)
 producerId: watteco


### PR DESCRIPTION
The `Vaqa'O`, `Vaqa'O lite` and `Vaqa'O plus` sensors all had the same name on thingpark.