### PR TITLE
TXIF-2615 - Adding updated driver's examples and sensors to Volley Boast new models

### DIFF
--- a/vendors/volley_boast/drivers/gp-1_v2/driver.yaml
+++ b/vendors/volley_boast/drivers/gp-1_v2/driver.yaml
@@ -1,0 +1,2 @@
+# A reference to the corresponding driver on our private drivers repository
+protocolId: vobo:node:1

--- a/vendors/volley_boast/drivers/hl-1_v2/driver.yaml
+++ b/vendors/volley_boast/drivers/hl-1_v2/driver.yaml
@@ -1,0 +1,2 @@
+# A reference to the corresponding driver on our private drivers repository
+protocolId: vobo:node:1

--- a/vendors/volley_boast/drivers/sl_v1/driver.yaml
+++ b/vendors/volley_boast/drivers/sl_v1/driver.yaml
@@ -1,0 +1,2 @@
+# A reference to the corresponding driver on our private drivers repository
+protocolId: vobo:node:1

--- a/vendors/volley_boast/drivers/tc_v1/driver.yaml
+++ b/vendors/volley_boast/drivers/tc_v1/driver.yaml
@@ -1,0 +1,2 @@
+# A reference to the corresponding driver on our private drivers repository
+protocolId: vobo:node:1

--- a/vendors/volley_boast/drivers/xp_v1/driver.yaml
+++ b/vendors/volley_boast/drivers/xp_v1/driver.yaml
@@ -1,0 +1,2 @@
+# A reference to the corresponding driver on our private drivers repository
+protocolId: vobo:node:1

--- a/vendors/volley_boast/models/gp-1/model.yaml
+++ b/vendors/volley_boast/models/gp-1/model.yaml
@@ -41,4 +41,4 @@ userGuideURL:
 # <sensor>:<unitId> Available sensors following Actility ontology: https://github.com/actility/device-catalog/blob/main/template/sample-vendor/drivers/ONTOLOGY.md
 sensors:
     - temperature:Cel
-    - batteryVoltage:V
+    - batteryVoltage:mV

--- a/vendors/volley_boast/models/gp-1_v2/model.yaml
+++ b/vendors/volley_boast/models/gp-1_v2/model.yaml
@@ -27,9 +27,40 @@ LoRaWANCertified:
 modelId: vobo:gp-1:2
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
 protocolId:
+    - vobo:node:1
 # DataSheet URL (optional) 
 specificationURL: https://volleyboast.com/products/Latest/VoBoGP1/DCM-0018-A5_VoBo_GP1_DataSheet.pdf
 # User Guide URL (optional) 
 userGuideURL: 
+examples:
+    vobo:node:1:
+        - "VoBo-XX Standard Payload."
+        - "VoBo Heartbeat V1 Payload."
+        - "VoBo Heartbeat V2 Payload."
+        - "VoBo-XX Engineering Units AIN1 & AIN2 Payload."
+        - "VoBo-XX Engineering Units AIN3 & Battery Level Payload."
+        - "VoBo-XX Engineering Units ADC Temperature Payload."
+        - "VoBo-XX Engineering Units Digital Inputs Payload."
+        - "VoBo-XX Event Log Payload."
+        - "VoBo General Configuration Payload."
+        - "VoBo VoBoSync Part 1 Configuration Payload."
+        - "VoBo VoBoSync Part 2 Configuration Payload."
+        - "VoBo-XX General Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 3 Configuration Payload."
+        - "Payload with invalid FPort"
+        - "Analog Sensor payload with unknown Sensor Number."
+        - "Analog Sensor payload with unknown Engineering Unit Code."
 # <sensor>:<unitId> Available sensors following Actility ontology: https://github.com/actility/device-catalog/blob/main/template/sample-vendor/drivers/ONTOLOGY.md
 sensors:
+    - batteryVoltage:mV
+    - voltage:V
+    - temperature:Cel
+    - current:mA

--- a/vendors/volley_boast/models/hl-1_v2/model.yaml
+++ b/vendors/volley_boast/models/hl-1_v2/model.yaml
@@ -27,9 +27,42 @@ LoRaWANCertified:
 modelId: vobo:hl-1:2
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
 protocolId:
+    - vobo:node:1
 # DataSheet URL (optional) 
 specificationURL: https://volleyboast.com/products/Latest/VoBoHL1/DCM-0017-A3_VoBo_HL1_DataSheet.pdf
 # User Guide URL (optional) 
 userGuideURL: 
+examples:
+    vobo:node:1:
+examples:
+    vobo:node:1:
+        - "VoBo-XX Standard Payload."
+        - "VoBo Heartbeat V1 Payload."
+        - "VoBo Heartbeat V2 Payload."
+        - "VoBo-XX Engineering Units AIN1 & AIN2 Payload."
+        - "VoBo-XX Engineering Units AIN3 & Battery Level Payload."
+        - "VoBo-XX Engineering Units ADC Temperature Payload."
+        - "VoBo-XX Engineering Units Digital Inputs Payload."
+        - "VoBo-XX Event Log Payload."
+        - "VoBo General Configuration Payload."
+        - "VoBo VoBoSync Part 1 Configuration Payload."
+        - "VoBo VoBoSync Part 2 Configuration Payload."
+        - "VoBo-XX General Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 3 Configuration Payload."
+        - "Payload with invalid FPort"
+        - "Analog Sensor payload with unknown Sensor Number."
+        - "Analog Sensor payload with unknown Engineering Unit Code."
 # <sensor>:<unitId> Available sensors following Actility ontology: https://github.com/actility/device-catalog/blob/main/template/sample-vendor/drivers/ONTOLOGY.md
 sensors:
+    - batteryVoltage:mV
+    - voltage:V
+    - temperature:Cel
+    - current:mA

--- a/vendors/volley_boast/models/sl_v1/model.yaml
+++ b/vendors/volley_boast/models/sl_v1/model.yaml
@@ -27,9 +27,42 @@ LoRaWANCertified:
 modelId: vobo:sl:1
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
 protocolId:
+    - vobo:node:1
 # DataSheet URL (optional) 
 specificationURL: https://volleyboast.com/products/Latest/VoBoSL/DCM-SL04-A1_VoBo_SL_Datasheet.pdf
 # User Guide URL (optional) 
 userGuideURL: 
+examples:
+    vobo:node:1:
+examples:
+    vobo:node:1:
+        - "VoBo-XX Standard Payload."
+        - "VoBo Heartbeat V1 Payload."
+        - "VoBo Heartbeat V2 Payload."
+        - "VoBo-XX Engineering Units AIN1 & AIN2 Payload."
+        - "VoBo-XX Engineering Units AIN3 & Battery Level Payload."
+        - "VoBo-XX Engineering Units ADC Temperature Payload."
+        - "VoBo-XX Engineering Units Digital Inputs Payload."
+        - "VoBo-XX Event Log Payload."
+        - "VoBo General Configuration Payload."
+        - "VoBo VoBoSync Part 1 Configuration Payload."
+        - "VoBo VoBoSync Part 2 Configuration Payload."
+        - "VoBo-XX General Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 3 Configuration Payload."
+        - "Payload with invalid FPort"
+        - "Analog Sensor payload with unknown Sensor Number."
+        - "Analog Sensor payload with unknown Engineering Unit Code."
 # <sensor>:<unitId> Available sensors following Actility ontology: https://github.com/actility/device-catalog/blob/main/template/sample-vendor/drivers/ONTOLOGY.md
 sensors:
+    - batteryVoltage:mV
+    - voltage:V
+    - temperature:Cel
+    - current:mA

--- a/vendors/volley_boast/models/tc_v1/model.yaml
+++ b/vendors/volley_boast/models/tc_v1/model.yaml
@@ -27,9 +27,51 @@ LoRaWANCertified:
 modelId: vobo:tc:1
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
 protocolId:
+    - vobo:node:1
 # DataSheet URL (optional) 
 specificationURL: https://volleyboast.com/products/Latest/VoBoTC/DCM-TC04-A3_VoBo_TC_Datasheet.pdf
 # User Guide URL (optional) 
 userGuideURL: 
+examples:
+    vobo:node:1:
+        - "VoBo-XX Standard Payload."
+        - "VoBo Heartbeat V1 Payload."
+        - "VoBo Heartbeat V2 Payload."
+        - "VoBo-XX Engineering Units AIN1 & AIN2 Payload."
+        - "VoBo-XX Engineering Units AIN3 & Battery Level Payload."
+        - "VoBo-XX Engineering Units ADC Temperature Payload."
+        - "VoBo-XX Engineering Units Digital Inputs Payload."
+        - "VoBo-XX Event Log Payload."
+        - "VoBo General Configuration Payload."
+        - "VoBo VoBoSync Part 1 Configuration Payload."
+        - "VoBo VoBoSync Part 2 Configuration Payload."
+        - "VoBo-XX General Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 3 Configuration Payload."
+        - "VoBo-TC Cold Joint Temperature & Battery Level Payload."
+        - "VoBo-TC TC1 & TC2 Payload."
+        - "VoBo-TC Digital Inputs Payload."
+        - "VoBo-TC General Configuration Payload."
+        - "VoBo-TC TC1 & TC2 Configuration Payload."
+        - "VoBo-TC TC3 & TC4 Configuration Payload."
+        - "VoBo-TC TC5 & TC6 Configuration Payload."
+        - "VoBo-TC TC7 & TC8 Configuration Payload."
+        - "VoBo-TC TC9 & TC10 Configuration Payload."
+        - "VoBo-TC TC11 & TC12 Configuration Payload."
+        - "VoBo-TC Event Log Payload."
+        - "Payload with invalid FPort"
+        - "Analog Sensor payload with unknown Sensor Number."
+        - "Analog Sensor payload with unknown Engineering Unit Code."
 # <sensor>:<unitId> Available sensors following Actility ontology: https://github.com/actility/device-catalog/blob/main/template/sample-vendor/drivers/ONTOLOGY.md
 sensors:
+    - batteryVoltage:mV
+    - voltage:V
+    - temperature:Cel
+    - current:mA

--- a/vendors/volley_boast/models/xp_v1/model.yaml
+++ b/vendors/volley_boast/models/xp_v1/model.yaml
@@ -27,9 +27,40 @@ LoRaWANCertified:
 modelId: vobo:xp:1
 # <vendorId>:<protocolName>:<protocolVersion> Needed for linking the model with a specific driver -> must be the same one used in driver.yaml in the corresponding model (You might have several ones)
 protocolId:
+    - vobo:node:1
 # DataSheet URL (optional) 
 specificationURL: https://volleyboast.com/products/Latest/VoBoXP/VoBo_XP_Datasheet_DCM-XP04-A1.pdf
 # User Guide URL (optional) 
 userGuideURL: 
+examples:
+    vobo:node:1:
+        - "VoBo-XX Standard Payload."
+        - "VoBo Heartbeat V1 Payload."
+        - "VoBo Heartbeat V2 Payload."
+        - "VoBo-XX Engineering Units AIN1 & AIN2 Payload."
+        - "VoBo-XX Engineering Units AIN3 & Battery Level Payload."
+        - "VoBo-XX Engineering Units ADC Temperature Payload."
+        - "VoBo-XX Engineering Units Digital Inputs Payload."
+        - "VoBo-XX Event Log Payload."
+        - "VoBo General Configuration Payload."
+        - "VoBo VoBoSync Part 1 Configuration Payload."
+        - "VoBo VoBoSync Part 2 Configuration Payload."
+        - "VoBo-XX General Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN1 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN2 Part 3 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 1 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 2 Configuration Payload."
+        - "VoBo-XX Engineering Units AIN3 Part 3 Configuration Payload."
+        - "Payload with invalid FPort"
+        - "Analog Sensor payload with unknown Sensor Number."
+        - "Analog Sensor payload with unknown Engineering Unit Code."
 # <sensor>:<unitId> Available sensors following Actility ontology: https://github.com/actility/device-catalog/blob/main/template/sample-vendor/drivers/ONTOLOGY.md
 sensors:
+    - batteryVoltage:mV
+    - voltage:V
+    - temperature:Cel
+    - current:mA


### PR DESCRIPTION
Updated Volley Boast's driver to 1.3.2. Needed to add sensors and driver examples to new Volley Boast models (gp-1_v2, hl-1_v2, sl_v1, tc_v1 and xp_v1)