### PR TITLE
TXIF-2779 - Fix drivers failed when testing with examples

### DIFF
--- a/template/sample-vendor/drivers/README.md
+++ b/template/sample-vendor/drivers/README.md
@@ -398,6 +398,8 @@ use cases as well as error cases.
 
 **Important:** The test of your driver is needed to prove a minimum test coverage of 85% to be valid on our framework.
 
+_**PS:** If your driver outputs values as ISO string dates or instances of class Date in the format "xxxx-xx-xxTxx:xx:xx.xxxZ", **declared when compiled**, you can validate the test by replacing the date value by_ "XXXX-XX-XXTXX:XX:XX.XXXZ" _in the JSON examples file._
+
 > A pre-implemented [spec file](sample-driver/driver-examples.spec.js) for testing can be copied from the template in order to test the driver with all the provided examples.
 
 ##

--- a/template/sample-vendor/drivers/sample-driver/driver-examples.spec.js
+++ b/template/sample-vendor/drivers/sample-driver/driver-examples.spec.js
@@ -24,6 +24,10 @@ describe("Decode uplink", () => {
 
                 // Then
                 const expected = example.output;
+
+                // Adaptations
+                checkDates(result, expected);
+
                 expect(result).toStrictEqual(expected);
             });
         }
@@ -49,6 +53,10 @@ describe("Decode downlink", () => {
 
                 // Then
                 const expected = example.output;
+
+                // Adaptations
+                checkDates(result, expected);
+
                 expect(result).toStrictEqual(expected);
             });
         }
@@ -69,3 +77,40 @@ describe("Encode downlink", () => {
         }
     });
 });
+
+
+// UTIL
+function checkDates(result, expected) {
+    for(let property of listProperties(result)) {
+        let keys = property.split('.');
+        let value = result;
+        for(let key of keys) {
+            value = value[key];
+        }
+
+        let keysStr = keys.join("\"][\"");
+
+        let isDate = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/.test(value);
+        isDate |= value instanceof Date;
+        
+        if(isDate) {
+            eval(`
+                if(value instanceof Date) result["${keysStr}"] = value.toISOString();
+                if(expected["${keysStr}"] === "XXXX-XX-XXTXX:XX:XX.XXXZ") result["${keysStr}"] = "XXXX-XX-XXTXX:XX:XX.XXXZ";
+            `)
+        }
+    }
+}
+
+function listProperties(obj, parent = '', result = []) {
+    for (let key in obj) {
+        if (obj.hasOwnProperty(key)) {
+            if (typeof obj[key] === 'object' && !(obj[key] instanceof Date) && obj[key] !== null) {
+                listProperties(obj[key], parent + key + '.', result);
+            } else {
+                result.push(parent + key);
+            }
+        }
+    }
+    return result;
+}

--- a/vendors/twtg/drivers/neon-ts/index.js
+++ b/vendors/twtg/drivers/neon-ts/index.js
@@ -1,19 +1,19 @@
 // Protocol v2 only
 
-if (typeof module !== 'undefined') {
-  // Only needed for nodejs
-  module.exports = {
-    Decode: Decode,
-    Decoder: Decoder,
-    decode_float: decode_float,
-    decode_uint32: decode_uint32,
-    decode_int32: decode_int32,
-    decode_uint16: decode_uint16,
-    decode_int16: decode_int16,
-    decode_uint8: decode_uint8,
-    decode_int8: decode_int8,
-  };
-}
+// if (typeof module !== 'undefined') {
+//   // Only needed for nodejs
+//   module.exports = {
+//     Decode: Decode,
+//     Decoder: Decoder,
+//     decode_float: decode_float,
+//     decode_uint32: decode_uint32,
+//     decode_int32: decode_int32,
+//     decode_uint16: decode_uint16,
+//     decode_int16: decode_int16,
+//     decode_uint8: decode_uint8,
+//     decode_int8: decode_int8,
+//   };
+// }
 
 // Decode an uplink message from a buffer
 // (array) of bytes to an object of fields.
@@ -345,29 +345,29 @@ Object.prototype.in = function() {
 
 // Protocol v2 only
 
-if (typeof module !== 'undefined') {
-  // Only needed for nodejs
-  module.exports = {
-    Encode: Encode,
-    Encoder: Encoder,
-    EncodeDeviceConfig: EncodeDeviceConfig, // used by generate_config_bin.py
-    EncodeTsAppConfig: EncodeTsAppConfig, // used by generate_config_bin.py
-    encode_header: encode_header,
-    encode_events_mode: encode_events_mode,
-    encode_device_config: encode_device_config,
-    encode_ts_app_config: encode_ts_app_config,
-    encode_config_switch_bitmask: encode_config_switch_bitmask,
-    encode_device_config_switch: encode_device_config_switch,
-    encode_device_type: encode_device_type,
-    encode_uint32: encode_uint32,
-    encode_int32: encode_int32,
-    encode_uint16: encode_uint16,
-    encode_int16: encode_int16,
-    encode_uint8: encode_uint8,
-    encode_int8: encode_int8,
-    calc_crc: calc_crc,
-  };
-}
+// if (typeof module !== 'undefined') {
+//   // Only needed for nodejs
+//   module.exports = {
+//     Encode: Encode,
+//     Encoder: Encoder,
+//     EncodeDeviceConfig: EncodeDeviceConfig, // used by generate_config_bin.py
+//     EncodeTsAppConfig: EncodeTsAppConfig, // used by generate_config_bin.py
+//     encode_header: encode_header,
+//     encode_events_mode: encode_events_mode,
+//     encode_device_config: encode_device_config,
+//     encode_ts_app_config: encode_ts_app_config,
+//     encode_config_switch_bitmask: encode_config_switch_bitmask,
+//     encode_device_config_switch: encode_device_config_switch,
+//     encode_device_type: encode_device_type,
+//     encode_uint32: encode_uint32,
+//     encode_int32: encode_int32,
+//     encode_uint16: encode_uint16,
+//     encode_int16: encode_int16,
+//     encode_uint8: encode_uint8,
+//     encode_int8: encode_int8,
+//     calc_crc: calc_crc,
+//   };
+// }
 
 var mask_byte = 255;
 
@@ -619,3 +619,5 @@ function calc_crc(buf) {
   while (i < buf.length) C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xFF];
   return C & 0xFFFF;
 }
+
+exports.Decode = Decode;

--- a/vendors/twtg/drivers/neon-ts/package.json
+++ b/vendors/twtg/drivers/neon-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-ts",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NEON Temperature Sensor driver",
   "main": "index.js",
   "scripts": {

--- a/vendors/twtg/drivers/neon-vs-mt/index.js
+++ b/vendors/twtg/drivers/neon-vs-mt/index.js
@@ -1,19 +1,19 @@
 // Protocol v2 only
 
-if (typeof module !== 'undefined') {
-  // Only needed for nodejs
-  module.exports = {
-    Decode: Decode,
-    Decoder: Decoder,
-    decode_float: decode_float,
-    decode_uint32: decode_uint32,
-    decode_int32: decode_int32,
-    decode_uint16: decode_uint16,
-    decode_int16: decode_int16,
-    decode_uint8: decode_uint8,
-    decode_int8: decode_int8,
-  };
-}
+// if (typeof module !== 'undefined') {
+//   // Only needed for nodejs
+//   module.exports = {
+//     Decode: Decode,
+//     Decoder: Decoder,
+//     decode_float: decode_float,
+//     decode_uint32: decode_uint32,
+//     decode_int32: decode_int32,
+//     decode_uint16: decode_uint16,
+//     decode_int16: decode_int16,
+//     decode_uint8: decode_uint8,
+//     decode_int8: decode_int8,
+//   };
+// }
 
 // Decode an uplink message from a buffer
 // (array) of bytes to an object of fields.
@@ -462,28 +462,28 @@ Object.prototype.in = function() {
 
 // Protocol v2 only
 
-if (typeof module !== 'undefined') {
-  // Only needed for nodejs
-  module.exports = {
-    Encode: Encode,
-    Encoder: Encoder,
-    EncodeDeviceConfig: EncodeDeviceConfig, // used by generate_config_bin.py
-    EncodeVsMtAppConfig: EncodeVsMtAppConfig, // used by generate_config_bin.py
-    encode_header: encode_header,
-    encode_device_config: encode_device_config,
-    encode_vsmt_app_config: encode_vsmt_app_config,
-    encode_config_switch_bitmask: encode_config_switch_bitmask,
-    encode_device_config_switch: encode_device_config_switch,
-    encode_device_type: encode_device_type,
-    encode_uint32: encode_uint32,
-    encode_int32: encode_int32,
-    encode_uint16: encode_uint16,
-    encode_int16: encode_int16,
-    encode_uint8: encode_uint8,
-    encode_int8: encode_int8,
-    calc_crc: calc_crc,
-  };
-}
+// if (typeof module !== 'undefined') {
+//   // Only needed for nodejs
+//   module.exports = {
+//     Encode: Encode,
+//     Encoder: Encoder,
+//     EncodeDeviceConfig: EncodeDeviceConfig, // used by generate_config_bin.py
+//     EncodeVsMtAppConfig: EncodeVsMtAppConfig, // used by generate_config_bin.py
+//     encode_header: encode_header,
+//     encode_device_config: encode_device_config,
+//     encode_vsmt_app_config: encode_vsmt_app_config,
+//     encode_config_switch_bitmask: encode_config_switch_bitmask,
+//     encode_device_config_switch: encode_device_config_switch,
+//     encode_device_type: encode_device_type,
+//     encode_uint32: encode_uint32,
+//     encode_int32: encode_int32,
+//     encode_uint16: encode_uint16,
+//     encode_int16: encode_int16,
+//     encode_uint8: encode_uint8,
+//     encode_int8: encode_int8,
+//     calc_crc: calc_crc,
+//   };
+// }
 
 var mask_byte = 255;
 
@@ -708,3 +708,5 @@ function calc_crc(buf) {
   while (i < buf.length) C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xFF];
   return C & 0xFFFF;
 }
+
+exports.Decode = Decode;

--- a/vendors/twtg/drivers/neon-vs-mt/package.json
+++ b/vendors/twtg/drivers/neon-vs-mt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-vs-mt",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NEON Multi Turn Valve Sensor driver",
   "main": "index.js",
   "scripts": {

--- a/vendors/twtg/drivers/neon-vs-qt/index.js
+++ b/vendors/twtg/drivers/neon-vs-qt/index.js
@@ -1,19 +1,19 @@
 // Protocol v2 only
 
-if (typeof module !== 'undefined') {
-  // Only needed for nodejs
-  module.exports = {
-    Decode: Decode,
-    Decoder: Decoder,
-    decode_float: decode_float,
-    decode_uint32: decode_uint32,
-    decode_int32: decode_int32,
-    decode_uint16: decode_uint16,
-    decode_int16: decode_int16,
-    decode_uint8: decode_uint8,
-    decode_int8: decode_int8,
-  };
-}
+// if (typeof module !== 'undefined') {
+//   // Only needed for nodejs
+//   module.exports = {
+//     Decode: Decode,
+//     Decoder: Decoder,
+//     decode_float: decode_float,
+//     decode_uint32: decode_uint32,
+//     decode_int32: decode_int32,
+//     decode_uint16: decode_uint16,
+//     decode_int16: decode_int16,
+//     decode_uint8: decode_uint8,
+//     decode_int8: decode_int8,
+//   };
+// }
 
 // helper function to parse an 32 bit float
 function decode_float(bytes, cursor) {
@@ -211,28 +211,28 @@ Object.prototype.in = function() {
 
 // Protocol v2 only
 
-if (typeof module !== 'undefined') {
-  // Only needed for nodejs
-  module.exports = {
-    Encode: Encode,
-    Encoder: Encoder,
-    EncodeDeviceConfig: EncodeDeviceConfig, // used by generate_config_bin.py
-    EncodeVsQtAppConfig: EncodeVsQtAppConfig, // used by generate_config_bin.py
-    encode_header: encode_header,
-    encode_device_config: encode_device_config,
-    encode_vsqt_app_config: encode_vsqt_app_config,
-    encode_config_switch_bitmask: encode_config_switch_bitmask,
-    encode_device_config_switch: encode_device_config_switch,
-    encode_device_type: encode_device_type,
-    encode_uint32: encode_uint32,
-    encode_int32: encode_int32,
-    encode_uint16: encode_uint16,
-    encode_int16: encode_int16,
-    encode_uint8: encode_uint8,
-    encode_int8: encode_int8,
-    calc_crc: calc_crc,
-  };
-}
+// if (typeof module !== 'undefined') {
+//   // Only needed for nodejs
+//   module.exports = {
+//     Encode: Encode,
+//     Encoder: Encoder,
+//     EncodeDeviceConfig: EncodeDeviceConfig, // used by generate_config_bin.py
+//     EncodeVsQtAppConfig: EncodeVsQtAppConfig, // used by generate_config_bin.py
+//     encode_header: encode_header,
+//     encode_device_config: encode_device_config,
+//     encode_vsqt_app_config: encode_vsqt_app_config,
+//     encode_config_switch_bitmask: encode_config_switch_bitmask,
+//     encode_device_config_switch: encode_device_config_switch,
+//     encode_device_type: encode_device_type,
+//     encode_uint32: encode_uint32,
+//     encode_int32: encode_int32,
+//     encode_uint16: encode_uint16,
+//     encode_int16: encode_int16,
+//     encode_uint8: encode_uint8,
+//     encode_int8: encode_int8,
+//     calc_crc: calc_crc,
+//   };
+// }
 
 /**
  * Device configuration encoder
@@ -700,3 +700,5 @@ function encodeDownlink(input) {
   var fport;
   return Encoder(input, fport);
 }
+
+exports.Decode = Decode;

--- a/vendors/twtg/drivers/neon-vs-qt/package.json
+++ b/vendors/twtg/drivers/neon-vs-qt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-vs-qt",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NEON Quarter Turn Valve Sensor driver",
   "main": "index.js",
   "scripts": {

--- a/vendors/yosensi/drivers/generic/driver-examples.spec.js
+++ b/vendors/yosensi/drivers/generic/driver-examples.spec.js
@@ -31,7 +31,26 @@ describe("Decode uplink", () => {
                 const result = driver.decodeUplink(input);
 
                 // Then
-                const expected = example.output;
+                let expected = example.output;
+                for(let property of listProperties(result)) {
+                    let keys = property.split('.');
+                    let value = result;
+                    for(let key of keys) {
+                        value = value[key];
+                    }
+
+                    let keysStr = keys.join("\"][\"");
+
+                    let isDate = false;
+                    try {
+                        isDate = (new Date(value)).toISOString() === value;
+                    } catch(err) {
+
+                    }
+                    if(isDate) {
+                        eval(`result["${keysStr}"] = "XXXX-XX-XXTXX:XX:XX.XXXZ"`)
+                    }
+                }
                 expect(result).toEqual(expected);
             });
         }
@@ -98,3 +117,16 @@ describe("Backward compatibility - Encode downlink", () => {
         }
     });
 });
+
+function listProperties(obj, parent = '', result = []) {
+    for (let key in obj) {
+        if (obj.hasOwnProperty(key)) {
+            if (typeof obj[key] === 'object' && obj[key] !== null) {
+                listProperties(obj[key], parent + key + '.', result);
+            } else {
+                result.push(parent + key);
+            }
+        }
+    }
+    return result;
+}

--- a/vendors/yosensi/drivers/generic/examples.json
+++ b/vendors/yosensi/drivers/generic/examples.json
@@ -12,7 +12,7 @@
         "measurements": [
             {
               "address": "",
-              "dateTime": "2023-08-01T16:06:19.659Z",
+              "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
               "type": 2,
               "typeName": "battery voltage",
               "typeUnits": "[mV]",
@@ -20,7 +20,7 @@
             },
             {
               "address": "",
-              "dateTime": "2023-08-01T16:06:19.659Z",
+              "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
               "type": 3,
               "typeName": "temperature",
               "typeUnits": "[°C]",
@@ -28,7 +28,7 @@
             },
             {
               "address": "",
-              "dateTime": "2023-08-01T16:06:19.659Z",
+              "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
               "type": 4,
               "typeName": "relative humidity",
               "typeUnits": "[%]",
@@ -36,7 +36,7 @@
             },
             {
               "address": "1900",
-              "dateTime": "2023-08-01T16:06:19.659Z",
+              "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
               "type": 16,
               "typeName": "three-value custom",
               "typeUnits": "",
@@ -44,7 +44,7 @@
             },
             {
               "address": "1901",
-              "dateTime": "2023-08-01T16:06:19.659Z",
+              "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
               "type": 16,
               "typeName": "three-value custom",
               "typeUnits": "",
@@ -52,7 +52,7 @@
             },
             {
               "address": "1902",
-              "dateTime": "2023-08-01T16:06:19.659Z",
+              "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
               "type": 16,
               "typeName": "three-value custom",
               "typeUnits": "",
@@ -60,7 +60,7 @@
             }
           ],
           "payloadCounter": 0,
-          "payloadCreationDateTime": "2023-08-01T16:06:19.659Z",
+          "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
           "payloadVersion": 2
       },
       "errors": [],
@@ -80,7 +80,7 @@
         "measurements": [
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.674Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 2,
             "typeName": "battery voltage",
             "typeUnits": "[mV]",
@@ -88,7 +88,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.674Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -96,7 +96,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.674Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 4,
             "typeName": "relative humidity",
             "typeUnits": "[%]",
@@ -104,7 +104,7 @@
           },
           {
             "address": "00",
-            "dateTime": "2023-08-01T16:06:19.674Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -112,7 +112,7 @@
           },
           {
             "address": "01",
-            "dateTime": "2023-08-01T16:06:19.674Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -120,7 +120,7 @@
           },
           {
             "address": "02",
-            "dateTime": "2023-08-01T16:06:19.674Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -128,7 +128,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.674Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 5,
             "typeName": "pressure",
             "typeUnits": "[hPa]",
@@ -136,7 +136,7 @@
           },
           {
             "address": "25",
-            "dateTime": "2023-08-01T16:06:19.674Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -144,7 +144,7 @@
           }
         ],
         "payloadCounter": 0,
-        "payloadCreationDateTime": "2023-08-01T16:06:19.674Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],
@@ -164,7 +164,7 @@
         "measurements": [
           {
             "address": "",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 2,
             "typeName": "battery voltage",
             "typeUnits": "[mV]",
@@ -172,7 +172,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -180,7 +180,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 4,
             "typeName": "relative humidity",
             "typeUnits": "[%]",
@@ -188,7 +188,7 @@
           },
           {
             "address": "00",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 17,
             "typeName": "four-value custom",
             "typeUnits": "",
@@ -196,7 +196,7 @@
           },
           {
             "address": "01",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 17,
             "typeName": "four-value custom",
             "typeUnits": "",
@@ -204,7 +204,7 @@
           },
           {
             "address": "02",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 17,
             "typeName": "four-value custom",
             "typeUnits": "",
@@ -212,7 +212,7 @@
           },
           {
             "address": "03",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 17,
             "typeName": "four-value custom",
             "typeUnits": "",
@@ -220,7 +220,7 @@
           },
           {
             "address": "00",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 25,
             "typeName": "custom",
             "typeUnits": "",
@@ -228,7 +228,7 @@
           },
           {
             "address": "01",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 25,
             "typeName": "custom",
             "typeUnits": "",
@@ -236,7 +236,7 @@
           },
           {
             "address": "02",
-            "dateTime": "2023-08-01T15:23:09.287Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 25,
             "typeName": "custom",
             "typeUnits": "",
@@ -244,7 +244,7 @@
           }
         ],
         "payloadCounter": 0,
-        "payloadCreationDateTime": "2023-08-01T15:23:09.287Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],
@@ -264,7 +264,7 @@
         "measurements": [
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.684Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 2,
             "typeName": "battery voltage",
             "typeUnits": "[mV]",
@@ -272,7 +272,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.684Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -280,7 +280,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.684Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 4,
             "typeName": "relative humidity",
             "typeUnits": "[%]",
@@ -288,7 +288,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.684Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 10,
             "typeName": "distance",
             "typeUnits": "[mm]",
@@ -296,7 +296,7 @@
           },
           {
             "address": "00",
-            "dateTime": "2023-08-01T16:06:19.684Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -304,7 +304,7 @@
           },
           {
             "address": "01",
-            "dateTime": "2023-08-01T16:06:19.684Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -312,7 +312,7 @@
           },
           {
             "address": "02",
-            "dateTime": "2023-08-01T16:06:19.684Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -320,7 +320,7 @@
           }
         ],
         "payloadCounter": 0,
-        "payloadCreationDateTime": "2023-08-01T16:06:19.684Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],
@@ -340,7 +340,7 @@
         "measurements": [
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.686Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 1,
             "typeName": "state",
             "typeUnits": "",
@@ -348,7 +348,7 @@
           },
           {
             "address": "00",
-            "dateTime": "2023-08-01T16:06:19.686Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -356,7 +356,7 @@
           },
           {
             "address": "01",
-            "dateTime": "2023-08-01T16:06:19.686Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -364,7 +364,7 @@
           },
           {
             "address": "02",
-            "dateTime": "2023-08-01T16:06:19.686Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -372,7 +372,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.686Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 2,
             "typeName": "battery voltage",
             "typeUnits": "[mV]",
@@ -380,7 +380,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.686Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -388,7 +388,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.686Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 4,
             "typeName": "relative humidity",
             "typeUnits": "[%]",
@@ -396,7 +396,7 @@
           }
         ],
         "payloadCounter": 0,
-        "payloadCreationDateTime": "2023-08-01T16:06:19.686Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],
@@ -416,7 +416,7 @@
         "measurements": [
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.689Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 2,
             "typeName": "battery voltage",
             "typeUnits": "[mV]",
@@ -424,7 +424,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.689Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -432,7 +432,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.689Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 4,
             "typeName": "relative humidity",
             "typeUnits": "[%]",
@@ -440,7 +440,7 @@
           },
           {
             "address": "00",
-            "dateTime": "2023-08-01T16:06:19.689Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 23,
             "typeName": "two-value custom",
             "typeUnits": "",
@@ -448,7 +448,7 @@
           },
           {
             "address": "01",
-            "dateTime": "2023-08-01T16:06:19.689Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 23,
             "typeName": "two-value custom",
             "typeUnits": "",
@@ -456,7 +456,7 @@
           }
         ],
         "payloadCounter": 0,
-        "payloadCreationDateTime": "2023-08-01T16:06:19.689Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],
@@ -476,7 +476,7 @@
         "measurements": [
           {
             "address": "01",
-            "dateTime": "2023-08-01T16:06:19.692Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 1,
             "typeName": "state",
             "typeUnits": "",
@@ -484,7 +484,7 @@
           },
           {
             "address": "12",
-            "dateTime": "2023-08-01T16:06:19.692Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 1,
             "typeName": "state",
             "typeUnits": "",
@@ -492,7 +492,7 @@
           },
           {
             "address": "13",
-            "dateTime": "2023-08-01T16:06:19.692Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 1,
             "typeName": "state",
             "typeUnits": "",
@@ -500,7 +500,7 @@
           },
           {
             "address": "04",
-            "dateTime": "2023-08-01T16:06:19.692Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 24,
             "typeName": "counter",
             "typeUnits": "",
@@ -508,7 +508,7 @@
           },
           {
             "address": "05",
-            "dateTime": "2023-08-01T16:06:19.692Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 24,
             "typeName": "counter",
             "typeUnits": "",
@@ -516,7 +516,7 @@
           },
           {
             "address": "06",
-            "dateTime": "2023-08-01T16:06:19.692Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 24,
             "typeName": "counter",
             "typeUnits": "",
@@ -524,7 +524,7 @@
           }
         ],
         "payloadCounter": 1,
-        "payloadCreationDateTime": "2023-08-01T16:06:19.692Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],
@@ -544,7 +544,7 @@
         "measurements": [
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.694Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -552,7 +552,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.694Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 4,
             "typeName": "relative humidity",
             "typeUnits": "[%]",
@@ -560,7 +560,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.694Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 6,
             "typeName": "illuminance",
             "typeUnits": "[lux]",
@@ -568,7 +568,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.694Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 8,
             "typeName": "TVOC concentration",
             "typeUnits": "[ppb]",
@@ -576,7 +576,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.694Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 26,
             "typeName": "CO",
             "typeUnits": "[ppm]",
@@ -584,7 +584,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.694Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 27,
             "typeName": "CO2",
             "typeUnits": "[ppm]",
@@ -592,7 +592,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.694Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 28,
             "typeName": "sound pressure level",
             "typeUnits": "[dB]",
@@ -600,7 +600,7 @@
           },
           {
             "address": "02",
-            "dateTime": "2023-08-01T16:06:19.694Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 9,
             "typeName": "dust concentration",
             "typeUnits": "[ug/m3]",
@@ -608,7 +608,7 @@
           }
         ],
         "payloadCounter": 0,
-        "payloadCreationDateTime": "2023-08-01T16:06:19.694Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],
@@ -628,7 +628,7 @@
         "measurements": [
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.696Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 2,
             "typeName": "battery voltage",
             "typeUnits": "[mV]",
@@ -636,7 +636,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.696Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -644,7 +644,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.696Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 4,
             "typeName": "relative humidity",
             "typeUnits": "[%]",
@@ -652,7 +652,7 @@
           },
           {
             "address": "6d",
-            "dateTime": "2023-08-01T16:06:19.696Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 5,
             "typeName": "pressure",
             "typeUnits": "[hPa]",
@@ -660,7 +660,7 @@
           },
           {
             "address": "6d",
-            "dateTime": "2023-08-01T16:06:19.696Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -668,7 +668,7 @@
           }
         ],
         "payloadCounter": 0,
-        "payloadCreationDateTime": "2023-08-01T16:06:19.696Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],
@@ -688,7 +688,7 @@
         "measurements": [
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.699Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 2,
             "typeName": "battery voltage",
             "typeUnits": "[mV]",
@@ -696,7 +696,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.699Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -704,7 +704,7 @@
           },
           {
             "address": "",
-            "dateTime": "2023-08-01T16:06:19.699Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 4,
             "typeName": "relative humidity",
             "typeUnits": "[%]",
@@ -712,7 +712,7 @@
           },
           {
             "address": "00",
-            "dateTime": "2023-08-01T16:06:19.699Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -720,7 +720,7 @@
           },
           {
             "address": "01",
-            "dateTime": "2023-08-01T16:06:19.699Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -728,7 +728,7 @@
           },
           {
             "address": "02",
-            "dateTime": "2023-08-01T16:06:19.699Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 16,
             "typeName": "three-value custom",
             "typeUnits": "",
@@ -736,7 +736,7 @@
           },
           {
             "address": "00",
-            "dateTime": "2023-08-01T16:06:19.699Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -744,7 +744,7 @@
           },
           {
             "address": "01",
-            "dateTime": "2023-08-01T16:06:19.699Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -752,7 +752,7 @@
           },
           {
             "address": "02",
-            "dateTime": "2023-08-01T16:06:19.699Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 3,
             "typeName": "temperature",
             "typeUnits": "[°C]",
@@ -760,7 +760,7 @@
           }
         ],
         "payloadCounter": 0,
-        "payloadCreationDateTime": "2023-08-01T16:06:19.699Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],
@@ -780,7 +780,7 @@
         "measurements": [
           {
             "address": "02c558",
-            "dateTime": "2023-08-01T16:05:20.702Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 36,
             "typeName": "generic modbus",
             "typeUnits": "",
@@ -788,7 +788,7 @@
           },
           {
             "address": "02c55e",
-            "dateTime": "2023-08-01T16:05:21.702Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 36,
             "typeName": "generic modbus",
             "typeUnits": "",
@@ -796,7 +796,7 @@
           },
           {
             "address": "02c560",
-            "dateTime": "2023-08-01T16:05:22.702Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 36,
             "typeName": "generic modbus",
             "typeUnits": "",
@@ -804,7 +804,7 @@
           },
           {
             "address": "02c582",
-            "dateTime": "2023-08-01T16:05:23.702Z",
+            "dateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
             "type": 36,
             "typeName": "generic modbus",
             "typeUnits": "",
@@ -812,7 +812,7 @@
           }
         ],
         "payloadCounter": 25,
-        "payloadCreationDateTime": "2023-08-01T16:05:19.702Z",
+        "payloadCreationDateTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
         "payloadVersion": 2
       },
       "errors": [],

--- a/vendors/yosensi/drivers/generic/package.json
+++ b/vendors/yosensi/drivers/generic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yosensi-generic-driver",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Yosensi generic driver",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Two fixes:
* new Date() generated while compiling replaced by XXXX-XX-XXTXX:XX:XX.XXXZ in the examples for unit testing
* Fixing TWTG drivers (failed exports on Decode and Encode functions)